### PR TITLE
Add wheel builds for macOS on Apple Silicon (arm64)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -126,14 +126,14 @@ jobs:
 
         # Visual Studio
       - name: Set up MSVC x86
-        if: matrix.os == 'windows-latest' && matrix.platform_id == 'win32'
+        if: matrix.platform_id == 'win32'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
 
         # Visual Studio
       - name: Set up MSVC x64
-        if: matrix.os == 'windows-latest' && matrix.platform_id == 'win_amd64'
+        if: matrix.platform_id == 'win_amd64'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,29 +9,110 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-10.15]
-        python: [36, 37, 38, 39, 310]
-        bitness: [32, 64]
         include:
-          # Run 32 and 64 bit version in parallel for Linux and Windows
+          # Windows 32-bit
           - os: windows-latest
-            bitness: 64
+            python: 36
+            platform_id: win32
+          - os: windows-latest
+            python: 37
+            platform_id: win32
+          - os: windows-latest
+            python: 38
+            platform_id: win32
+          - os: windows-latest
+            python: 39
+            platform_id: win32
+          - os: windows-latest
+            python: 310
+            platform_id: win32
+
+          # Windows 64-bit
+          - os: windows-latest
+            python: 36
             platform_id: win_amd64
           - os: windows-latest
-            bitness: 32
-            platform_id: win32
+            python: 37
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 38
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+
+          # Linux 32-bit
           - os: ubuntu-latest
-            bitness: 64
+            python: 36
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 37
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_i686
+
+          # Linux 64-bit
+          - os: ubuntu-latest
+            python: 36
             platform_id: manylinux_x86_64
           - os: ubuntu-latest
-            bitness: 32
-            platform_id: manylinux_i686
-          - os: macOS-10.15
-            bitness: 64
+            python: 37
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+
+          # macOS on Intel 64-bit
+          - os: macos-latest
+            python: 36
+            arch: x86_64
             platform_id: macosx_x86_64
-        exclude:
-          - os: macOS-10.15
-            bitness: 32
+          - os: macos-latest
+            python: 37
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 38
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 39
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 310
+            arch: x86_64
+            platform_id: macosx_x86_64
+
+          # macOS on Apple M1 64-bit
+          - os: macos-latest
+            python: 38
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 39
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 310
+            arch: arm64
+            platform_id: macosx_arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -45,14 +126,14 @@ jobs:
 
         # Visual Studio
       - name: Set up MSVC x86
-        if: matrix.os == 'windows-latest' && matrix.bitness == '32'
+        if: matrix.os == 'windows-latest' && matrix.platform_id == 'win32'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
 
         # Visual Studio
       - name: Set up MSVC x64
-        if: matrix.os == 'windows-latest' && matrix.bitness == '64'
+        if: matrix.os == 'windows-latest' && matrix.platform_id == 'win_amd64'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel
@@ -85,10 +166,10 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: |
             choco upgrade chocolatey -y
             choco install swig -f -y --no-progress
-            pip install ninja cmake
 
-          CIBW_BEFORE_ALL_MACOS: |
-            brew install swig ninja cmake
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}
+          CIBW_BEFORE_ALL_MACOS: brew install swig
 
         run: python -m cibuildwheel --output-dir wheelhouse
 

--- a/README.md
+++ b/README.md
@@ -17,32 +17,32 @@ pip install -U python-gdcm
 
 ### From source
 
-###### Install dependencies
+#### Install dependencies
 - Compiler for you platform (GCC, Clang, MSVC)
 - [CMake](https://cmake.org/)
 - [SWIG](http://www.swig.org/)
 - [patchelf](https://github.com/NixOS/patchelf) will also be needed on Linux
 - [Git](https://git-scm.com/) to get the source code
 
-###### Setup environment
+#### Setup environment
 If the `cmake` or `swig` executables aren't in `$PATH`, either add them or create  `CMAKE_EXE` and `SWIG_EXE` envars:
 ```bash
 export CMAKE_EXE="path/to/cmake/executable"
 export SWIG_EXE="path/to/swig/executable"
 ```
 
-###### Clone source
+#### Clone source
 ```bash
 git clone --recurse-submodules https://github.com/tfmoraes/python-gdcm
 ```
 
-###### Build and install
+#### Build and install
 ```bash
 # Note the trailing slash!
 pip install python-gdcm/
 ```
 
-###### Test installed package
+#### Test installed package
 ```bash
 python -c "import gdcm; print(gdcm.GDCM_VERSION)"
 ```

--- a/README.md
+++ b/README.md
@@ -1,36 +1,52 @@
+[![Python version](https://img.shields.io/pypi/pyversions/python-gdcm.svg)](https://img.shields.io/pypi/pyversions/python-gdcm.svg)
+[![PyPI version](https://badge.fury.io/py/python-gdcm.svg)](https://badge.fury.io/py/python-gdcm)
+
 # Python-GDCM
 
-**Unoficial** [GDCM](http://gdcm.sourceforge.net/wiki/index.php/Main_Page) packages for Python.
+**Unofficial** [GDCM](http://gdcm.sourceforge.net/wiki/index.php/Main_Page) packages for Python 3 on Linux, Windows and MacOS (both Intel and Apple Silicon).
 
-Grassroots DiCoM is a C++ library for DICOM medical files. It is automatically wrapped to python/C#/Java (using swig). It supports RAW,JPEG (lossy/lossless),J2K,JPEG-LS, RLE and deflated. It also comes with DICOM Part 3,6 & 7 of the standard as XML files.
+Grassroots DiCoM is a C++ library for [DICOM](https://www.dicomstandard.org/) medical files that can be wrapped for Python using [SWIG](http://www.swig.org/). It supports datasets encoded using native, JPEG, JPEG 2000, JPEG-LS, RLE and deflated transfer syntaxes. It also comes with Parts 3, 6 & 7 of the DICOM Standard as XML files.
 
 ## Installation
 
-### Using PIP
+### Using pip
 
-```
-pip install python-gdcm
+```bash
+pip install -U python-gdcm
 ```
 
 ### From source
 
-- Install building dependencies
-    - Compiler for you platform (GCC, Clang, MSVC)
-    - Cmake (https://cmake.org/) 
-    - Swig (http://www.swig.org/)
-- Build and install python-gdcm
-    - If cmake isn't in `$PATH` export the env variable `CMAKE_EXE` to its path
-        ```
-        $ export CMAKE_EXE=/CMAKE/PATH
-        ```
-    - If swig isn't in `$PATH` export the env variable `SWIG_EXE` to its path
-        ```
-        $ export SWIG_EXE=/SWIG/PATH
-        ```
-    - Build and install
-        ```                                                                
-        $ python setup.py install
-        ```
+###### Install dependencies
+- Compiler for you platform (GCC, Clang, MSVC)
+- [CMake](https://cmake.org/)
+- [SWIG](http://www.swig.org/)
+- [patchelf](https://github.com/NixOS/patchelf) will also be needed on Linux
+- [Git](https://git-scm.com/) to get the source code
+
+###### Setup environment
+If the `cmake` or `swig` executables aren't in `$PATH`, either add them or create  `CMAKE_EXE` and `SWIG_EXE` envars:
+```bash
+export CMAKE_EXE="path/to/cmake/executable"
+export SWIG_EXE="path/to/swig/executable"
+```
+
+###### Clone source
+```bash
+git clone --recurse-submodules https://github.com/tfmoraes/python-gdcm
+```
+
+###### Build and install
+```bash
+# Note the trailing slash!
+pip install python-gdcm/
+```
+
+###### Test installed package
+```bash
+python -c "import gdcm; print(gdcm.GDCM_VERSION)"
+```
+If you get a `ModuleNotFoundError: No module named '_gdcm.gdcmswig'` error then make sure your current working directory doesn't contain a `_gdcm` folder.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "ninja >= 1.10.2.3",
+    "cmake >= 3.22.1",
+]


### PR DESCRIPTION
* Add arm64 wheel builds for macOS (i.e. on Apple Silicon/M1) with Python 3.8+
  * But I don't have Apple hardware to test that the wheels are OK (and GitHub don't have macOS M1 environments)
* Add `pyproject.toml` to simplify build process
* Fix typos and update build instructions in `README.md`