### PR TITLE
Support using system CMake and Ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools >= 61.0",
     "wheel",
-    "ninja >= 1.10.2.3",
-    "cmake >= 3.22.1",
 ]
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,13 @@ class CMakeBuildExt(build_ext):
             super().build_extension(ext)
 
 
+SETUP_REQUIRES = []
+if CMAKE_EXE is None:
+    SETUP_REQUIRES += ["cmake >= 3.22.1"]
+if shutil.which("ninja") is None:
+    SETUP_REQUIRES += ["ninja >= 1.10.2.3"]
+
+
 setuptools.setup(
     ext_package="_gdcm",
     ext_modules=[
@@ -199,4 +206,5 @@ setuptools.setup(
     cmdclass={
         "build_ext": CMakeBuildExt,
     },
+    setup_requires=SETUP_REQUIRES,
 )


### PR DESCRIPTION
Add `cmake` and `ninja` PyPI dependencies only if the respective programs are not found, and use system tools instead.  This avoids unnecessary dependencies on third-party binary packages, and improves portability by using downstream-patched CMake version.